### PR TITLE
NE: vif.binding=lswitch hook for OVS-backed extensions

### DIFF
--- a/api/src/main/java/org/apache/cloudstack/extension/ExtensionHelper.java
+++ b/api/src/main/java/org/apache/cloudstack/extension/ExtensionHelper.java
@@ -43,6 +43,30 @@ public interface ExtensionHelper {
      */
     String NETWORK_SERVICE_CAPABILITIES_DETAIL_KEY = "network.service.capabilities";
 
+    /**
+     * Detail key used by an OVS-backed NetworkOrchestrator extension to declare
+     * how its Logical Switch Port name should be matched against the OVS
+     * {@code external_ids:iface-id} written by libvirt on the hypervisor.
+     *
+     * <p>Currently supported value:</p>
+     * <ul>
+     *   <li>{@code "lswitch"} — the framework sets {@code BroadcastDomainType.Lswitch}
+     *   on the {@link com.cloud.vm.NicProfile} during {@code prepare(...)} and
+     *   propagates {@code nic.getUuid()} to per-NIC script commands as
+     *   {@code --nic-uuid}.  The extension is then expected to use that UUID as
+     *   the LSP name, so it matches the {@code interfaceid} that
+     *   {@code OvsVifDriver} emits in the libvirt {@code <virtualport>} for
+     *   {@code Lswitch} broadcast type.</li>
+     * </ul>
+     *
+     * <p>If absent, the framework keeps the network's broadcast type unchanged
+     * (typically {@code Vlan}) and does not propagate {@code --nic-uuid}.</p>
+     */
+    String VIF_BINDING_DETAIL_KEY = "vif.binding";
+
+    /** Value of {@link #VIF_BINDING_DETAIL_KEY} that selects the Lswitch path. */
+    String VIF_BINDING_LSWITCH = "lswitch";
+
     String getExtensionScriptPath(Extension extension);
 
     /**

--- a/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/NetworkExtensionElement.java
+++ b/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/NetworkExtensionElement.java
@@ -518,8 +518,33 @@ public class NetworkExtensionElement extends AdapterBase implements
         // libvirt sets external_ids:iface-id atomically with tap creation.
         // No agent patch is required for this binding mode.
         if (isLswitchVifBinding(network)) {
+            // Override broadcast type + URI on the NicProfile (in-memory),
+            // and persist the same to the underlying nics row so listNics
+            // / DB queries report consistent OVN identifiers instead of
+            // the stale VLAN URI the GuestNetworkGuru allocated at
+            // design-time.
+            java.net.URI ovnUri = null;
+            try {
+                ovnUri = java.net.URI.create("ovn://cs-net-" + network.getId());
+            } catch (Exception e) {
+                logger.warn("Failed to build OVN URI for NIC {}: {}", nic.getId(), e.getMessage());
+            }
             nic.setBroadcastType(Networks.BroadcastDomainType.Lswitch);
-            logger.debug("prepare: applied Lswitch broadcast type to NIC {} (uuid={}) on network {} per extension vif.binding hint",
+            if (ovnUri != null) {
+                nic.setBroadcastUri(ovnUri);
+                nic.setIsolationUri(ovnUri);
+                try {
+                    com.cloud.vm.NicVO nicVo = nicDao.findById(nic.getId());
+                    if (nicVo != null) {
+                        nicVo.setBroadcastUri(ovnUri);
+                        nicVo.setIsolationUri(ovnUri);
+                        nicDao.update(nicVo.getId(), nicVo);
+                    }
+                } catch (Exception e) {
+                    logger.warn("Failed to persist OVN URI on nics row {}: {}", nic.getId(), e.getMessage());
+                }
+            }
+            logger.debug("prepare: applied Lswitch broadcast type and ovn:// URI to NIC {} (uuid={}) on network {} per extension vif.binding hint",
                     nic.getId(), nic.getUuid(), network.getId());
         }
 

--- a/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/NetworkExtensionElement.java
+++ b/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/NetworkExtensionElement.java
@@ -19,6 +19,7 @@ package org.apache.cloudstack.framework.extensions.network;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +119,7 @@ import org.apache.cloudstack.engine.orchestration.service.NetworkOrchestrationSe
 import org.apache.cloudstack.extension.Extension;
 import org.apache.cloudstack.extension.ExtensionHelper;
 import org.apache.cloudstack.extension.NetworkCustomActionProvider;
+import org.apache.cloudstack.framework.extensions.dao.ExtensionDetailsDao;
 import org.apache.cloudstack.resourcedetail.dao.VpcDetailsDao;
 import org.apache.commons.lang3.StringUtils;
 
@@ -241,6 +243,8 @@ public class NetworkExtensionElement extends AdapterBase implements
     @Inject
     private PhysicalNetworkDao physicalNetworkDao;
     @Inject
+    private ExtensionDetailsDao extensionDetailsDao;
+    @Inject
     private DataCenterDao dataCenterDao;
     @Inject
     private VlanDao vlanDao;
@@ -306,6 +310,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         copy.networkDetailsDao              = this.networkDetailsDao;
         copy.ipAddressManager               = this.ipAddressManager;
         copy.physicalNetworkDao             = this.physicalNetworkDao;
+        copy.extensionDetailsDao            = this.extensionDetailsDao;
         copy.dataCenterDao                  = this.dataCenterDao;
         copy.vlanDao                        = this.vlanDao;
         copy.guestOSCategoryDao             = this.guestOSCategoryDao;
@@ -506,10 +511,66 @@ public class NetworkExtensionElement extends AdapterBase implements
             return false;
         }
 
+        // VIF binding hint -- when the extension declares vif.binding=lswitch,
+        // override the NicProfile's broadcast type so OvsVifDriver picks the
+        // Lswitch path on the KVM agent.  That path already emits libvirt
+        // <virtualport type='openvswitch' interfaceid='<nic.getUuid()>'/> and
+        // libvirt sets external_ids:iface-id atomically with tap creation.
+        // No agent patch is required for this binding mode.
+        if (isLswitchVifBinding(network)) {
+            nic.setBroadcastType(Networks.BroadcastDomainType.Lswitch);
+            logger.debug("prepare: applied Lswitch broadcast type to NIC {} (uuid={}) on network {} per extension vif.binding hint",
+                    nic.getId(), nic.getUuid(), network.getId());
+        }
+
         final NetworkOfferingVO offering = networkOfferingDao.findById(network.getNetworkOfferingId());
         implement(network, offering, dest, context);
 
         return true;
+    }
+
+    /**
+     * Returns {@code true} when the extension that owns the given network
+     * declares {@code vif.binding=lswitch} in its {@code extension_details}.
+     * Used by {@link #prepare(Network, NicProfile, VirtualMachineProfile,
+     * DeployDestination, ReservationContext)} to switch the NIC's
+     * {@link Networks.BroadcastDomainType} to {@code Lswitch} so the KVM
+     * agent's existing {@code OvsVifDriver} Lswitch path is exercised --
+     * see the framework README for the full contract.
+     */
+    private boolean isLswitchVifBinding(Network network) {
+        try {
+            Extension extension = resolveExtension(network);
+            if (extension == null) {
+                return false;
+            }
+            Map<String, String> details = extensionDetailsDao.listDetailsKeyPairs(extension.getId());
+            if (details == null) {
+                return false;
+            }
+            String vifBinding = details.get(ExtensionHelper.VIF_BINDING_DETAIL_KEY);
+            return ExtensionHelper.VIF_BINDING_LSWITCH.equalsIgnoreCase(vifBinding);
+        } catch (Exception e) {
+            logger.debug("Failed to resolve vif.binding for network {}: {}", network.getId(), e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Returns {@code ["--nic-uuid", "<uuid>"]} when the extension prefers the
+     * Lswitch VIF binding path so the script can use the same UUID as the LSP
+     * name (matching the {@code interfaceid} that {@code OvsVifDriver} emits).
+     * Returns an empty list when the extension does not opt in -- existing
+     * extensions that derive identifiers from the MAC keep working unchanged.
+     */
+    private List<String> getNicUuidArgs(Network network, NicProfile nic) {
+        if (nic == null || nic.getUuid() == null || nic.getUuid().isBlank()) {
+            return Collections.emptyList();
+        }
+        if (!isLswitchVifBinding(network)) {
+            return Collections.emptyList();
+        }
+        return List.of("--nic-uuid", nic.getUuid());
     }
 
     @Override
@@ -1346,6 +1407,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--default-nic");  args.add(String.valueOf(nic.isDefaultNic()));
         args.add("--domain");       args.add(safeStr(network.getNetworkDomain()));
         args.add("--extension-ip"); args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "add-dhcp-entry", args.toArray(new String[0]));
     }
@@ -1434,6 +1496,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--mac");          args.add(safeStr(nic.getMacAddress()));
         args.add("--ip");           args.add(safeStr(nic.getIPv4Address()));
         args.add("--extension-ip"); args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "remove-dhcp-entry", args.toArray(new String[0]));
     }
@@ -1456,6 +1519,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--ip");           args.add(safeStr(nic.getIPv4Address()));
         args.add("--hostname");     args.add(safeStr(hostname));
         args.add("--extension-ip"); args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "add-dns-entry", args.toArray(new String[0]));
     }
@@ -1632,6 +1696,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--ip");           args.add(safeStr(nicIpAddress));
         args.add("--gateway");      args.add(safeStr(nic.getIPv4Gateway()));
         args.add("--extension-ip"); args.add(safeStr(ensureExtensionIp(network)));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScriptWithFilePayload(network, "save-vm-data", "--vm-data-file",
                 vmDataArg, args.toArray(new String[0]));
@@ -1655,6 +1720,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--gateway");      args.add(safeStr(nic.getIPv4Gateway()));
         args.add("--password");     args.add(password);
         args.add("--extension-ip"); args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "save-password", args.toArray(new String[0]));
     }
@@ -1681,6 +1747,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--gateway");      args.add(safeStr(nic.getIPv4Gateway()));
         args.add("--userdata");     args.add(userData);
         args.add("--extension-ip"); args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "save-userdata", args.toArray(new String[0]));
     }
@@ -1704,6 +1771,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--gateway");      args.add(safeStr(nic.getIPv4Gateway()));
         args.add("--sshkey");       args.add(sshKeyBase64);
         args.add("--extension-ip"); args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "save-sshkey", args.toArray(new String[0]));
     }
@@ -1727,6 +1795,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         args.add("--gateway");             args.add(safeStr(nic.getIPv4Gateway()));
         args.add("--hypervisor-hostname"); args.add(hostname);
         args.add("--extension-ip");        args.add(safeStr(extensionIp));
+        args.addAll(getNicUuidArgs(network, nic));
         args.addAll(getVpcIdArgs(network));
         return executeScript(network, "save-hypervisor-hostname", args.toArray(new String[0]));
     }

--- a/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/NetworkExtensionElement.java
+++ b/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/NetworkExtensionElement.java
@@ -52,6 +52,8 @@ import com.cloud.network.Network.Service;
 import com.cloud.network.NetworkModel;
 import com.cloud.network.Networks;
 import com.cloud.network.dao.NetworkDetailVO;
+import com.cloud.network.dao.NetworkDao;
+import com.cloud.network.dao.NetworkVO;
 import com.cloud.network.dao.PhysicalNetworkDao;
 import com.cloud.network.dao.PhysicalNetworkVO;
 import com.cloud.network.PhysicalNetworkServiceProvider;
@@ -245,6 +247,8 @@ public class NetworkExtensionElement extends AdapterBase implements
     @Inject
     private ExtensionDetailsDao extensionDetailsDao;
     @Inject
+    private NetworkDao networkDao;
+    @Inject
     private DataCenterDao dataCenterDao;
     @Inject
     private VlanDao vlanDao;
@@ -311,6 +315,7 @@ public class NetworkExtensionElement extends AdapterBase implements
         copy.ipAddressManager               = this.ipAddressManager;
         copy.physicalNetworkDao             = this.physicalNetworkDao;
         copy.extensionDetailsDao            = this.extensionDetailsDao;
+        copy.networkDao                     = this.networkDao;
         copy.dataCenterDao                  = this.dataCenterDao;
         copy.vlanDao                        = this.vlanDao;
         copy.guestOSCategoryDao             = this.guestOSCategoryDao;
@@ -464,6 +469,27 @@ public class NetworkExtensionElement extends AdapterBase implements
 
         if (!result) {
             return false;
+        }
+
+        // When the extension declares vif.binding=lswitch, also update the
+        // Network row itself so listNetworks / DB queries advertise the
+        // OVN-flavoured identifier instead of the cosmetic VLAN URI the
+        // GuestNetworkGuru allocated at design-time.  Format follows the
+        // legacy ovn-plugin convention: ``ovn://cs-net-<networkId>``.
+        if (isLswitchVifBinding(network)) {
+            try {
+                NetworkVO networkVo = networkDao.findById(network.getId());
+                if (networkVo != null) {
+                    java.net.URI ovnUri = java.net.URI.create("ovn://cs-net-" + network.getId());
+                    networkVo.setBroadcastDomainType(Networks.BroadcastDomainType.Lswitch);
+                    networkVo.setBroadcastUri(ovnUri);
+                    networkDao.update(networkVo.getId(), networkVo);
+                    logger.debug("implement: applied Lswitch broadcast type and ovn:// URI to network {} per extension vif.binding hint",
+                            network.getId());
+                }
+            } catch (Exception e) {
+                logger.warn("Failed to persist OVN URI on network {}: {}", network.getId(), e.getMessage());
+            }
         }
 
         // Step 3: Configure source NAT for both VPC and non-VPC networks for

--- a/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/README.md
+++ b/framework/extensions/src/main/java/org/apache/cloudstack/framework/extensions/network/README.md
@@ -71,8 +71,9 @@ hosts.  Use it as a working example.
 8. [Capabilities Configuration](#capabilities-configuration)
 9. [VPC Networks](#vpc-networks)
 10. [Extension IP](#extension-ip)
-11. [Exit Codes](#exit-codes)
-12. [Minimal Script Skeleton](#minimal-script-skeleton)
+11. [VIF Binding for OVS-backed Extensions](#vif-binding-for-ovs-backed-extensions)
+12. [Exit Codes](#exit-codes)
+13. [Minimal Script Skeleton](#minimal-script-skeleton)
 
 ---
 
@@ -636,6 +637,7 @@ network whose DHCP service is provided by this extension.
 | `--default-nic <bool>` | `true` if this is the VM's default NIC. |
 | `--domain <name>` | Network domain suffix (e.g. `cs.example.com`). |
 | `--extension-ip <ip>` | |
+| `--nic-uuid <uuid>` | (optional) Present only when the extension declared `vif.binding=lswitch`.  Carries `nic.getUuid()` so the extension can use it as the SDN-side port identifier (matches `external_ids:iface-id` set by libvirt on the OVS tap).  See [VIF Binding for OVS-backed Extensions](#vif-binding-for-ovs-backed-extensions). |
 | `--vpc-id <N>` | (optional) |
 
 **`remove-dhcp-entry` arguments:**
@@ -1103,6 +1105,77 @@ To use this extension as a VPC provider:
   helper): CloudStack allocates a dedicated IP from the guest subnet and passes
   it.  The device must listen on this IP for DHCP, DNS, and metadata (port 80)
   requests.
+
+---
+
+## VIF Binding for OVS-backed Extensions
+
+Extensions that drive OVS-based fabrics (OVN, NSX-OVS, …) need the OVS
+tap interface that libvirt creates for each VM NIC to carry the
+`external_ids:iface-id` value that the SDN controller expects.  CloudStack
+already does the right thing for `BroadcastDomainType.Lswitch` networks:
+its `OvsVifDriver` emits
+
+```xml
+<virtualport type='openvswitch'>
+  <parameters interfaceid='<nic.getUuid()>'/>
+</virtualport>
+```
+
+and libvirt sets `external_ids:iface-id=<nic-uuid>` on the tap atomically
+with port creation.  No agent patch is required.
+
+To opt into this binding mode an extension declares it as a top-level
+capability hint in its `extension_details`:
+
+```bash
+cmk createExtension \
+    name=my-ovs-sdn \
+    type=NetworkOrchestrator \
+    "details[0].key=network.services" \
+    "details[0].value=Dhcp,Dns,UserData,SourceNat,…" \
+    "details[1].key=network.service.capabilities" \
+    "details[1].value=$(cat my-caps.json)" \
+    "details[2].key=vif.binding" \
+    "details[2].value=lswitch"
+```
+
+When `vif.binding=lswitch` is present:
+
+1. **`prepare()` overrides the NIC broadcast type.**
+   `NetworkExtensionElement.prepare(...)` calls
+   `nic.setBroadcastType(Networks.BroadcastDomainType.Lswitch)` so
+   `OvsVifDriver` on the KVM agent picks the existing Lswitch path and
+   emits the libvirt `<virtualport>` shown above.
+
+2. **Per-NIC commands receive `--nic-uuid <uuid>`.**
+   `add-dhcp-entry`, `remove-dhcp-entry`, `add-dns-entry`, `save-vm-data`,
+   `save-password`, `save-userdata`, `save-sshkey`, and
+   `save-hypervisor-hostname` all gain a `--nic-uuid <uuid>` argument
+   carrying `nic.getUuid()`.
+
+3. **The script must use `--nic-uuid` as the SDN-side port identifier.**
+   Whatever object the extension creates on its controller (OVN
+   Logical_Switch_Port, NSX logical port, …) **must be named exactly the
+   value of `--nic-uuid`**.  That is the string libvirt will write to
+   `external_ids:iface-id` on the tap, so the SDN controller's local
+   agent (e.g. `ovn-controller`) finds a match and binds the port.
+
+When the extension does not declare `vif.binding`, the framework keeps
+the default `BroadcastDomainType.Vlan` and does not propagate
+`--nic-uuid` -- existing reference extensions (e.g.
+`network-namespace`) are unaffected.
+
+### Why not the extension setting `iface-id` remotely?
+
+The OVS tap only exists *after* libvirt creates the VM, so any remote
+write from the extension would race `ovn-controller` on the host.  By
+letting libvirt do the write atomically with tap creation, the binding
+is ready by the time the controller scans the bridge.
+
+The extension may still talk OVSDB to the host (read-only checks,
+`bridge-mappings` setup, post-incident repair) -- but never for the
+boot path.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an opt-in hook so a NetworkOrchestrator extension backed by an OVS+OVN
datapath (or any other host-side stack that consumes the libvirt
`<virtualport interfaceid=…>` element) can declare `vif.binding=lswitch`
in its `extension_details` and have the framework wire the binding for
free.

When the hint is set, `NetworkExtensionElement.prepare()` flips the
`NicProfile` to `BroadcastDomainType.Lswitch` and persists
`broadcast_uri` / `isolation_uri` as `ovn://cs-net-<networkId>` on the
`nics` row, and `implement()` does the same on the `networks` row.
That is enough for the existing `OvsVifDriver` on the KVM agent to emit
`<virtualport type='openvswitch'><parameters interfaceid='<nic.uuid>'/>`
without any agent patch — libvirt sets `external_ids:iface-id=<nic.uuid>`
atomically with tap creation, and `ovn-controller` binds the LSP whose
name matches.

The framework also propagates `nic.getUuid()` to per-NIC script
commands as `--nic-uuid`, so the extension can use the canonical UUID
as the LSP name and stay in sync with what libvirt writes on the host.

Without the hint, behaviour is byte-identical to the current PR.

## Commits

1. **NE: VIF binding hooks for OVS-backed extensions** — adds the two
   public constants on `ExtensionHelper` (`VIF_BINDING_DETAIL_KEY`,
   `VIF_BINDING_LSWITCH`), the `--nic-uuid` propagation, and the
   broadcast-type override in `prepare()`. Also extends the framework
   README with the binding contract:
   `nic.uuid == libvirt iface-id == OVS external_ids:iface-id == OVN LSP name == OVN SB Port_Binding.logical_port`.
2. **NE: persist OVN broadcast/isolation URI on NIC** — sets
   `nic.broadcastUri` / `nic.isolationUri` to `ovn://cs-net-<id>` and
   persists via `nicDao.update()` so `listNics` and the UI advertise
   the OVN URI rather than the VLAN URI the GuestNetworkGuru allocates
   at design-time.
3. **NE: persist OVN broadcast type and URI on Network** — does the
   same on the `Network` row in `implement()` so `listNetworks`
   matches.

## Why these belong in the framework

The broadcast type / URI are read by `OvsVifDriver` *before* the
extension script runs, and they live in DAOs the script cannot touch.
The hook has to be in the Java `prepare()` / `implement()` flow.

## Risk surface

Three files, +219/−2 lines, all under `framework/extensions/.../network/`
plus 24 lines of constants in `api/.../extension/ExtensionHelper.java`.
No SQL migration, no new Cmd, no new response object. Existing
extensions (HyperV, MaaS, Proxmox) are untouched because they don't
declare `vif.binding=lswitch`.

## Lab validation

End-to-end on an isolated OVN network and a VPC tier:

- VM NIC bound on libvirt → OVS `iface-id` matches `nic.uuid`
  → OVN SB `Port_Binding.logical_port` matches → ovn-controller
  installs flows.
- listNetworks / listNics / network-detail UI show
  `ovn://cs-net-<id>` instead of `vlan://<id>`.
- DHCP, DNS, SourceNat, StaticNat, PortForward, Firewall (ingress and
  egress), Public LB and Internal LB all functional.

## Test plan

- [ ] Boot a VM on an extension-backed network whose extension declares
      `vif.binding=lswitch`; confirm `ovs-vsctl list interface` shows
      `iface-id=<nic.uuid>` and that `ovn-sbctl find port_binding
      logical_port=<nic.uuid>` returns one row with the chassis bound.
- [ ] Boot a VM on an extension that does NOT declare the detail;
      confirm broadcast type stays `Vlan` and `--nic-uuid` is not
      propagated to the script.
- [ ] Run `listNetworks` and `listNics` and verify the URI fields read
      `ovn://cs-net-<id>` after the network is implemented.